### PR TITLE
[feat] Access & Refresh Token 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,17 @@ dependencies {
 
 	// API Docs
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	//Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// ModelMapper
+	implementation 'org.modelmapper:modelmapper:3.2.1'
 }
 
 /** Jacoco start **/

--- a/gradlew
+++ b/gradlew
@@ -43,7 +43,7 @@
 #       by Bash, Ksh, etc; in particular arrays are avoided.
 #
 #       The "traditional" practice of packing multiple parameters into a
-#       space-separated string is a well documented source of bugs and security
+#       space-separated string is a well documented source of bugs and auth
 #       problems, so this is (mostly) avoided, by progressively accumulating
 #       options in "$@", and eventually passing that to Java.
 #

--- a/src/main/java/com/goldmarket/common/auth/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/goldmarket/common/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package com.goldmarket.common.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goldmarket.common.exception.ErrorCode;
+import com.goldmarket.common.exception.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "FORBIDDEN_EXCEPTION_HANDLER")
+@AllArgsConstructor
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error("권한이 없습니다.", accessDeniedException);
+
+        ResponseEntity<ErrorResponse<Void>> errorResponse = ErrorResponse.toResponseEntity(
+            ErrorCode.ACCESS_FORBIDDEN);
+
+        String responseBody = objectMapper.writeValueAsString(errorResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(ErrorCode.ACCESS_FORBIDDEN.getHttpStatus().value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/goldmarket/common/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/goldmarket/common/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.goldmarket.common.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goldmarket.common.exception.ErrorCode;
+import com.goldmarket.common.exception.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import javax.print.attribute.standard.Media;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "UNAUTHORIZATION_EXCEPTION_HANDLER")
+@AllArgsConstructor
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+        log.error("인증되지 않은 사용자입니다.", authException);
+
+        ResponseEntity<ErrorResponse<Void>> errorResponse = ErrorResponse.toResponseEntity(
+            ErrorCode.INVALID_TOKEN_UNAUTHORIZED);
+
+        String responseBody = objectMapper.writeValueAsString(errorResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(ErrorCode.INVALID_TOKEN_UNAUTHORIZED.getHttpStatus().value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/goldmarket/common/auth/CustomUserDetails.java
+++ b/src/main/java/com/goldmarket/common/auth/CustomUserDetails.java
@@ -1,0 +1,26 @@
+package com.goldmarket.common.auth;
+
+import com.goldmarket.member.dto.CustomUserInfo;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final CustomUserInfo info;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() { return info.getPassword(); }
+
+    @Override
+    public String getUsername() {
+        return info.getName();
+    }
+}

--- a/src/main/java/com/goldmarket/common/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/goldmarket/common/auth/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package com.goldmarket.common.auth;
+
+import com.goldmarket.member.domain.Member;
+import com.goldmarket.member.dto.CustomUserInfo;
+import com.goldmarket.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+    private final ModelMapper mapper;
+
+    @Override
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        Member member = memberRepository.findById(Long.parseLong(id))
+            .orElseThrow(() -> new UsernameNotFoundException("해당하는 회원을 찾을 수 없습니다"));
+
+        CustomUserInfo info = mapper.map(member, CustomUserInfo.class);
+
+        return new CustomUserDetails(info);
+    }
+
+}

--- a/src/main/java/com/goldmarket/common/auth/JwtAuthFilter.java
+++ b/src/main/java/com/goldmarket/common/auth/JwtAuthFilter.java
@@ -1,0 +1,56 @@
+package com.goldmarket.common.auth;
+
+import com.goldmarket.common.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil jwtUtil;
+
+    public static final String HEADER_KEY = "Authorization";
+    public static final String PREFIX = "Bearer ";
+
+    /*
+    * JWT 토큰 검증 필터 수행
+    * */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader(HEADER_KEY);
+
+        // JWT가 헤더에 있는 경우
+        if (authorizationHeader != null && authorizationHeader.startsWith(PREFIX)) {
+            String token = authorizationHeader.substring(7);
+            // JWT 유효성 검증
+            if (jwtUtil.validateToken(token)) {
+                Long userId = jwtUtil.getUserId(token);
+
+                // 유저와 토큰 일치 시 userDetails 생성
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(userId.toString());
+
+                if (userDetails != null) {
+                    // 접근권한 인증 Token 생성
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+                    // 현재 Request의 Security Context에 접근권한 설정
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                }
+            }
+        }
+
+        filterChain.doFilter(request, response);    // 다음 필터로 넘기기
+
+    }
+}

--- a/src/main/java/com/goldmarket/common/config/AppConfig.java
+++ b/src/main/java/com/goldmarket/common/config/AppConfig.java
@@ -1,0 +1,16 @@
+package com.goldmarket.common.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public ModelMapper modelMapper() { return new ModelMapper(); }
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/goldmarket/common/config/SecurityConfig.java
+++ b/src/main/java/com/goldmarket/common/config/SecurityConfig.java
@@ -1,0 +1,69 @@
+package com.goldmarket.common.config;
+
+import com.goldmarket.common.auth.CustomAccessDeniedHandler;
+import com.goldmarket.common.auth.CustomAuthenticationEntryPoint;
+import com.goldmarket.common.auth.CustomUserDetailsService;
+import com.goldmarket.common.auth.JwtAuthFilter;
+import com.goldmarket.common.util.JwtUtil;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+@AllArgsConstructor
+public class SecurityConfig {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil jwtUtil;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    private static final String[] AUTH_WHITELIST = {
+        "/h2-console/**","/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+        "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/api/v1/auth/**"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // CSRF, CORS
+        http.csrf((csrf) -> csrf.disable());
+        http.cors(Customizer.withDefaults());
+
+        // 세션 관리 상태 없음으로 구성
+        http.sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+            SessionCreationPolicy.STATELESS));
+
+        // FormLogin, BasicHttp 비활성화
+        http.formLogin((form) -> form.disable());
+        http.httpBasic(AbstractHttpConfigurer::disable);
+
+        // X-Frame-Options 설정
+        http.headers((headers) -> headers.frameOptions(FrameOptionsConfig::sameOrigin));
+
+        // JwtAuthFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
+        http.addFilterBefore(new JwtAuthFilter(customUserDetailsService, jwtUtil),
+            UsernamePasswordAuthenticationFilter.class);
+
+        http.exceptionHandling((exceptionHandling) -> exceptionHandling
+            .authenticationEntryPoint(authenticationEntryPoint)
+            .accessDeniedHandler(accessDeniedHandler));
+
+        // 권한 규칙
+        http.authorizeHttpRequests(authorize -> authorize
+            .requestMatchers(AUTH_WHITELIST).permitAll()
+            .anyRequest().permitAll());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/goldmarket/common/exception/ErrorCode.java
+++ b/src/main/java/com/goldmarket/common/exception/ErrorCode.java
@@ -18,6 +18,16 @@ public enum ErrorCode {
     MISSING_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 요청 값이 누락되었거나 잘못되었습니다."),
 
     /**
+     * 401 Unauthorized
+     */
+    INVALID_TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+
+    /**
+     * 403 - Forbidden
+     */
+    ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "서비스 회원이 아닙니다. 이메일 인증을 먼저 해주세요."),
+
+    /**
      * 500 - Internal Server Error
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.")

--- a/src/main/java/com/goldmarket/common/util/JwtUtil.java
+++ b/src/main/java/com/goldmarket/common/util/JwtUtil.java
@@ -1,0 +1,124 @@
+package com.goldmarket.common.util;
+
+import com.goldmarket.member.dto.CustomUserInfo;
+import com.goldmarket.member.dto.JwtTokenRes;
+import com.goldmarket.refresh_token.domain.RefreshToken;
+import com.goldmarket.refresh_token.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.sql.Date;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final Key key;
+    private final long accessTokenExpTime;
+    private final long refreshTokenExpTime;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public JwtUtil(
+        @Value("${JWT_SECRET}") String secretKey,
+        @Value("${JWT_ACCESS}") long accessTokenExpTime,
+        @Value("${JWT_REFRESH}") long refreshTokenExpTime,
+        RefreshTokenRepository refreshTokenRepository
+    ) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpTime = accessTokenExpTime;
+        this.refreshTokenExpTime = refreshTokenExpTime;
+    }
+
+    /*
+     * Access Token & Refresh Token 생성
+     * */
+    public JwtTokenRes generateAccessAndRefreshToken(CustomUserInfo member) {
+        return JwtTokenRes.builder()
+            .grantType("Bearer")
+            .accessToken(generateToken(member, "Access"))
+            .refreshToken(generateToken(member, "Refresh"))
+            .build();
+    }
+
+    /*
+     * JWT 생성
+     * */
+    private String generateToken(CustomUserInfo member, String tokenType) {
+
+        long expireTime = tokenType.equals("Access") ? accessTokenExpTime : refreshTokenExpTime;
+
+        Claims claims = Jwts.claims();
+        claims.put("id", member.getId());
+        claims.put("name", member.getName());
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(expireTime);
+
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(Date.from(now.toInstant()))
+            .setExpiration(Date.from(tokenValidity.toInstant()))
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    /*
+     * Token에서 User ID 추출
+     * */
+    public Long getUserId(String token) {
+        return parseClaims(token).get("id", Long.class);
+    }
+
+    /*
+     * JWT 검증
+     * */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("유효하지 않은 JWT Token입니다.", e);
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT Token입니다.", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("지원하지 않는 JWT Token입니다.", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims이 비어 있습니다.", e);
+        }
+        return false;
+    }
+
+    public boolean validateRefreshToken(String token) {
+        if (!validateToken(token)) {
+            return false;
+        }
+        Optional<RefreshToken> refreshToken = refreshTokenRepository.findById(getUserId(token));
+        return refreshToken.isPresent() && token.equals(refreshToken.get().getToken());
+    }
+
+    /*
+     * JWT Claims 추출
+     * */
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken)
+                .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/goldmarket/member/controller/MemberController.java
+++ b/src/main/java/com/goldmarket/member/controller/MemberController.java
@@ -1,0 +1,44 @@
+package com.goldmarket.member.controller;
+
+import com.goldmarket.member.dto.JwtTokenReq;
+import com.goldmarket.member.dto.JwtTokenRes;
+import com.goldmarket.member.dto.JwtTokenVerifyReq;
+import com.goldmarket.member.dto.JwtTokenVerityRes;
+import com.goldmarket.member.service.MemberAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "인증 및 인가")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class MemberController {
+
+    private final MemberAuthService memberAuthService;
+
+    @PostMapping("/token")
+    @Operation(summary = "토큰 발급")
+    public ResponseEntity<JwtTokenRes> getToken(
+        @Valid @RequestBody JwtTokenReq req
+    ) {
+        JwtTokenRes jwtTokenRes = this.memberAuthService.getToken(req);
+        return ResponseEntity.status(HttpStatus.OK).body(jwtTokenRes);
+    }
+
+    @PostMapping("/verifyToken")
+    @Operation(summary = "토큰 검증")
+    public ResponseEntity<JwtTokenVerityRes> getToken(
+        @Valid @RequestBody JwtTokenVerifyReq req
+    ) {
+        JwtTokenVerityRes jwtTokenVerityRes = this.memberAuthService.verityToken(req);
+        return ResponseEntity.status(HttpStatus.OK).body(jwtTokenVerityRes);
+    }
+}

--- a/src/main/java/com/goldmarket/member/dto/CustomUserInfo.java
+++ b/src/main/java/com/goldmarket/member/dto/CustomUserInfo.java
@@ -1,0 +1,16 @@
+package com.goldmarket.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomUserInfo {
+    private Long id;
+    private String name;
+    private String password;
+}

--- a/src/main/java/com/goldmarket/member/dto/JwtTokenReq.java
+++ b/src/main/java/com/goldmarket/member/dto/JwtTokenReq.java
@@ -1,0 +1,22 @@
+package com.goldmarket.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(title = "AUTH_REQ_01 : 토큰 발급 요청 DTO")
+public class JwtTokenReq {
+
+    @NotNull(message = "사용자 이름 입력은 필수입니다.")
+    private String name;
+
+    @NotNull(message = "패스워드 입력은 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/goldmarket/member/dto/JwtTokenRes.java
+++ b/src/main/java/com/goldmarket/member/dto/JwtTokenRes.java
@@ -1,0 +1,16 @@
+package com.goldmarket.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(title = "AUTH_RES_01 : 토큰 발급 응답 DTO")
+public class JwtTokenRes {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/goldmarket/member/dto/JwtTokenVerifyReq.java
+++ b/src/main/java/com/goldmarket/member/dto/JwtTokenVerifyReq.java
@@ -1,0 +1,5 @@
+package com.goldmarket.member.dto;
+
+public class JwtTokenVerifyReq {
+
+}

--- a/src/main/java/com/goldmarket/member/dto/JwtTokenVerityRes.java
+++ b/src/main/java/com/goldmarket/member/dto/JwtTokenVerityRes.java
@@ -1,0 +1,15 @@
+package com.goldmarket.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(title = "AUTH_RES_02 : 토큰 검증 응답 DTO")
+public class JwtTokenVerityRes {
+    String isValid;
+    String username;
+}

--- a/src/main/java/com/goldmarket/member/repository/MemberRepository.java
+++ b/src/main/java/com/goldmarket/member/repository/MemberRepository.java
@@ -2,7 +2,11 @@ package com.goldmarket.member.repository;
 
 import com.goldmarket.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Member findMemberByName(String name);
 
 }

--- a/src/main/java/com/goldmarket/member/service/MemberAuthService.java
+++ b/src/main/java/com/goldmarket/member/service/MemberAuthService.java
@@ -1,0 +1,67 @@
+package com.goldmarket.member.service;
+
+import com.goldmarket.common.util.JwtUtil;
+import com.goldmarket.member.domain.Member;
+import com.goldmarket.member.dto.CustomUserInfo;
+import com.goldmarket.member.dto.JwtTokenReq;
+import com.goldmarket.member.dto.JwtTokenRes;
+import com.goldmarket.member.dto.JwtTokenVerifyReq;
+import com.goldmarket.member.dto.JwtTokenVerityRes;
+import com.goldmarket.member.repository.MemberRepository;
+import com.goldmarket.refresh_token.domain.RefreshToken;
+import com.goldmarket.refresh_token.repository.RefreshTokenRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberAuthService {
+
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder encoder;
+    private final ModelMapper modelMapper;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public JwtTokenRes getToken(JwtTokenReq req) {
+        String name = req.getName();
+        String password = req.getPassword();
+        Member member = memberRepository.findMemberByName(name);
+        if (member == null) {
+            throw new UsernameNotFoundException("존재하지 않는 사용자입니다.");
+        }
+
+        if (!encoder.matches(password, member.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        CustomUserInfo info = modelMapper.map(member, CustomUserInfo.class);
+        JwtTokenRes jwtTokenRes = jwtUtil.generateAccessAndRefreshToken(info);
+
+        // 발급한 refresh token을 DB에 저장
+        Optional<RefreshToken> refreshToken = refreshTokenRepository.findByMember_Id(member.getId());
+
+        if (refreshToken.isPresent()) {
+            refreshTokenRepository.save(
+                refreshToken.get().updateToken(jwtTokenRes.getRefreshToken()));
+        } else {
+            refreshTokenRepository.save(RefreshToken.builder()
+                .member(member)
+                .token(jwtTokenRes.getRefreshToken())
+                .build());
+        }
+        return jwtTokenRes;
+    }
+
+    @Transactional
+    public JwtTokenVerityRes verityToken(JwtTokenVerifyReq req) {
+        return null;
+    }
+}

--- a/src/main/java/com/goldmarket/refresh_token/domain/RefreshToken.java
+++ b/src/main/java/com/goldmarket/refresh_token/domain/RefreshToken.java
@@ -1,0 +1,41 @@
+package com.goldmarket.refresh_token.domain;
+
+import com.goldmarket.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Builder
+    public RefreshToken(Member member, String token) {
+        this.member = member;
+        this.token = token;
+    }
+
+    public RefreshToken updateToken(String token) {
+        this.token = token;
+        return this;
+    }
+}

--- a/src/main/java/com/goldmarket/refresh_token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/goldmarket/refresh_token/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.goldmarket.refresh_token.repository;
+
+import com.goldmarket.refresh_token.domain.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByMember_Id(Long id);
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,2 +1,2 @@
 INSERT IGNORE INTO member (id, name, password)
-VALUES (1, 'gold', '83d6fddf033b3ed08b4fe3cc0e6cb2d848fba373bc340190050630c7a8e7de4d');
+VALUES (1, 'gold', '$2a$10$cAz0EmZYfqzngI46j91lX.GdJ9hlmYbMsOa5Esr0Hh.rwyfDb8dYW');

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,6 +1,14 @@
 CREATE TABLE IF NOT EXISTS member
 (
     id        BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name      VARCHAR(50)       NOT NULL,
+    name      VARCHAR(50) UNIQUE NOT NULL,
     password  VARCHAR(255)       NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS refresh_token
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    token       VARCHAR(1024)     NOT NULL,
+    member_id   BIGINT            NOT NULL,
+    CONSTRAINT fk_member_refresh_token FOREIGN KEY (member_id) REFERENCES member(id)
 );


### PR DESCRIPTION
## 🔥 구현 기능
> Username 및 Password를 담아 요청을 보내면 토큰을 발급합니다.

## 🔥 구현 방법
회원가입 기능을 구현하는 대신 사용자 더미데이터를 생성하였습니다.
```
name: gold
password: password
```
로 테스트 가능합니다.  

1. DB에 저장된 사용자 정보와 일치하는지 체크합니다.
2. 일치한다면 JwtUtil 클래스의 토큰 생성 메서드를 통해 Access & Refresh Token을 생성합니다.
3. 생성한 토큰을 DTO에 담아 반환합니다.


## 🔥 관련 이슈
related: #1
    
## 참고 할만한 자료(선택)
